### PR TITLE
bump aws cookbook version dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,6 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/tonyfruzza/slack_speak'
 issues_url 'https://github.com/tonyfruzza/slack_speak/issues'
 supports 'amazon'
-version '0.1.9'
+version '0.1.10'
 
-depends 'aws', '~> 7.3'
+depends 'aws', '~> 8.0.3'


### PR DESCRIPTION
* bump aws cookbook to 8.0.3 to be compatible with newer cookbook changes.